### PR TITLE
[0.1.9] Add support for Flux Standard Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ function putArticle(article) {
 putArticle(article);
 ```
 
-takes the above [`MajicDataEntity`](./src/types.js#L67) of an article (with its related entites expanded) and turns it in to a JsonAPI Request object
+takes the above [`MajicDataEntity`](./src/types.js#L67) of an article (with its related entites expanded) and turns it in to a JsonAPI Request object below. Notice that the object returns an array on the primary `data` key. As of version 0.1.9, to return an object on the primary `data` key, pass an optional options third parameter: `{single: true}`.
 
 ```javascript
 {
@@ -585,7 +585,7 @@ We have several helpers that make working with Redux and `MajicEntities` extreme
 
 #### Action Creators
 
-To start, we have a standard action creator, [`createMajicAction`](./src/redux/actions.js#L9), which returns objects of type [`MajicAction`](./src/redux/types.js#L16).
+To start, we have a standard action creator, [`createMajicAction`](./src/redux/actions.js#L9), which returns objects of type [`MajicAction`](./src/redux/types.js#L16). As of version 0.1.9, `MajicActions` are also valid [`Flux Standard Actions`](https://github.com/acdlite/flux-standard-action)!
 
 ```javascript
 type MajicAction = {
@@ -594,7 +594,8 @@ type MajicAction = {
     meta: {},
     callbacks: {
         [string]: ?Function,
-    }
+    },
+    error: boolean
 }
 ```
 

--- a/src/api/compose.js
+++ b/src/api/compose.js
@@ -2,7 +2,6 @@
 
 import {isEmpty, get} from '../utils';
 import type {
-    JsonApiResponse,
     JsonApiRequestRelationship,
     JsonApiRelationshipData,
     MajicCompositionSchema,
@@ -13,7 +12,13 @@ import type {
     MajicJsonApiEntity,
 } from '../types';
 
-export function composeRequest(data: MajicDataEntity, schema: MajicCompositionSchema): MajicJsonApiRequest {
+type ComposeOptions = {single: boolean};
+
+export function composeRequest(
+  data: MajicDataEntity,
+  schema: MajicCompositionSchema,
+  options: ComposeOptions = {single: false}
+): MajicJsonApiRequest {
     validateSchema(schema);
 
     if (!data.id) {
@@ -100,7 +105,7 @@ export function composeRequest(data: MajicDataEntity, schema: MajicCompositionSc
     };
 
     return {
-        data: [responseData],
+        data: options.single ? responseData : [responseData],
         ...(isEmpty(included) ? {} : {included}),
         ...(isEmpty(topLevelMeta) ? {} : {meta: topLevelMeta}),
     };

--- a/src/redux/actions.js
+++ b/src/redux/actions.js
@@ -4,7 +4,7 @@ import type {ReceiveMajicMeta, MajicAction} from './types';
 import type {ParsedMajicObjects} from '../types';
 import {RECEIVE_MAJIC_ENTITIES, CLEAR_NAMESPACE} from './constants';
 
-export function createMajicAction(type: string, payload: {} = {}, meta: {} = {}, callbacks: {[string]: Function} = {}): MajicAction {
+export function createMajicAction(type: string, payload: {} = {}, meta: {} = {}, callbacks: {[string]: Function} = {}, error: boolean = false): MajicAction {
     return {
         type,
         payload,
@@ -13,6 +13,7 @@ export function createMajicAction(type: string, payload: {} = {}, meta: {} = {},
             default: null,
             ...callbacks,
         },
+        error,
     };
 }
 

--- a/src/redux/types.js
+++ b/src/redux/types.js
@@ -19,5 +19,6 @@ export type MajicAction = {
     meta: {},
     callbacks: {
         [string]: ?Function,
-    }
+    },
+    error: boolean,
 };

--- a/src/types.js
+++ b/src/types.js
@@ -71,7 +71,7 @@ export type MajicDataEntity = {
 };
 
 export type MajicJsonApiRequest = {
-    data: MajicJsonApiEntity[],
+    data: MajicJsonApiEntity|MajicJsonApiEntity[],
     meta?: {},
     included?: MajicJsonApiEntity[],
 };

--- a/tests/api/compose.test.js
+++ b/tests/api/compose.test.js
@@ -170,10 +170,18 @@ describe('composeRequest', () => {
         expect(actual).toEqual(expected);
     });
 
-    it('properly returns the fully composed JsonAPI request object', () => {
+    it('properly returns the fully composed JsonAPI request object, as a data array when no options object is omitted', () => {
         data = states.article1toCompose;
-        expected = states.composedArticle1
+        expected = states.composedArticle1;
         actual = compose.composeRequest(data, schema);
+
+        expect(actual).toEqual(expected);
+    });
+
+    it('properly returns the fully composed JsonAPI request object, as a data object with {single: true} options object', () => {
+        data = states.article1toCompose;
+        expected = states.composedSingleArticle1;
+        actual = compose.composeRequest(data, schema, {single: true});
 
         expect(actual).toEqual(expected);
     });

--- a/tests/redux/actions.test.js
+++ b/tests/redux/actions.test.js
@@ -7,6 +7,7 @@ describe('createMajicAction', () => {
     let payload;
     let meta;
     let callbacks;
+    let error;
     let actual;
     let expected;
 
@@ -15,9 +16,10 @@ describe('createMajicAction', () => {
         payload = {};
         meta = {};
         callbacks = {};
+        error = true;
     });
 
-    it('returns an object passing through the received `type`, `payload`, and `meta`, and ensures callbacks has a null default', () => {
+    it('returns an object passing through the received `type`, `payload`, `meta`, and `error`, and ensures callbacks has a null default', () => {
         expected = {
             type,
             payload,
@@ -25,9 +27,26 @@ describe('createMajicAction', () => {
             callbacks: {
                 default: null,
             },
+            error: false,
         };
 
         actual = actions.createMajicAction(type, payload, meta);
+
+        expect(actual).toEqual(expected);
+    });
+
+    it('returns an object passing through the received `type`, `payload`, `meta`, and `error`, and ensures callbacks has a null default', () => {
+        expected = {
+            type,
+            payload,
+            meta,
+            callbacks: {
+                default: null,
+            },
+            error: true,
+        };
+
+        actual = actions.createMajicAction(type, payload, meta, callbacks, error);
 
         expect(actual).toEqual(expected);
     });
@@ -40,6 +59,7 @@ describe('createMajicAction', () => {
             callbacks: {
                 default: null,
             },
+            error: false,
         };
 
         actual = actions.createMajicAction(type);

--- a/tests/states.js
+++ b/tests/states.js
@@ -821,6 +821,82 @@ export const composedArticle1 = {
         }
     ]
 };
+export const composedSingleArticle1 = {
+    "meta": {
+        "requestId": 42
+    },
+    "data": {
+        "type": "articles",
+        "id": "1",
+        "attributes": {
+            "title": "JSON API paints my bikeshed!"
+        },
+        "relationships": {
+            "author": {
+                "data": {
+                    "type": "people",
+                    "id": "9"
+                }
+            },
+            "comments": {
+                "data": [
+                    {
+                        "type": "comments",
+                        "id": "5"
+                    },
+                    {
+                        "type": "comments",
+                        "id": "12"
+                    }
+                ]
+            }
+        },
+        "meta": {
+            "revisionNumber": 1
+        }
+    },
+    "included": [
+        {
+            "type": "people",
+            "id": "9",
+            "attributes": {
+                "first-name": "Dan",
+                "last-name": "Gebhardt",
+                "twitter": "dgeb"
+            }
+        },
+        {
+            "type": "comments",
+            "id": "5",
+            "attributes": {
+                "body": "First!"
+            },
+            "relationships": {
+                "author": {
+                    "data": {
+                        "type": "people",
+                        "id": "2"
+                    }
+                }
+            }
+        },
+        {
+            "type": "comments",
+            "id": "12",
+            "attributes": {
+                "body": "I like XML better"
+            },
+            "relationships": {
+                "author": {
+                    "data": {
+                        "type": "people",
+                        "id": "9"
+                    }
+                }
+            }
+        }
+    ]
+};
 
 export const metaComposedArticle1 = {
     "data": [


### PR DESCRIPTION
- Adds support for FSA by adding error key to `MajicAction`
- Add optional `options` parameter `composeRequest`
    - `{single: boolean}`, defaults to `{single: false}`
- Bump version
- Update README